### PR TITLE
fix: client can't read the env EUREKA_SERVER_ADDRESS

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ env:
 eureka:
   client:
     serviceUrl:
-      defaultZone: $EUREKA_SERVER_ADDRESS
+      defaultZone: ${EUREKA_SERVER_ADDRESS}
 ```
 
 #### 第二种方式


### PR DESCRIPTION
In my case, if I only use `$EUREKA_SERVER_ADDRESS`, the eureka client can't get the environment variable